### PR TITLE
fix: update outlets and schedule datasets trigger to ODS_USERDATA

### DIFF
--- a/dags/ods/user/info.py
+++ b/dags/ods/user/info.py
@@ -31,7 +31,7 @@ with DAG(
         # порядок датасетов здесь важен!
         # см. info.sql и https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#variables
         inlets=[Dataset("STG_USERDATA.info"), Dataset("STG_USERDATA.param"), Dataset("STG_UNION_MEMBER.union_member")],
-        outlets=[Dataset("ODS_USER_INFO.info")],
+        outlets=[Dataset("ODS_USERDATA")],
         params={"tablename": "info"},
     )
     # run_sql_encrypted = PostgresOperator(

--- a/dags/ods/user/info.py
+++ b/dags/ods/user/info.py
@@ -12,7 +12,7 @@ from plugins.features import get_sql_code
 
 
 with DAG(
-    dag_id="ODS_USER_INFO.info",
+    dag_id="ODS_USERDATA",
     start_date=datetime(2024, 10, 1),
     schedule=[Dataset("STG_USERDATA.info"), Dataset("STG_USERDATA.param"), Dataset("STG_UNION_MEMBER.union_member")],
     catchup=False,
@@ -46,6 +46,6 @@ with DAG(
     #         Dataset("STG_USERDATA.param"),
     #         Dataset("STG_UNION_MEMBER.union_member"),
     #     ],
-    #     outlets=[Dataset("ODS_USER_INFO.encrypted_info")],
+    #     outlets=[Dataset("ODS_USERDATA.encrypted_info")],
     #     params={"tablename": "encrypted_info"},
     # ) TODO сделать мерж юсердаты шифрованной

--- a/dags/ods/user/user_to_back.py
+++ b/dags/ods/user/user_to_back.py
@@ -273,10 +273,10 @@ def post_members_to_union_group_to_backend(union_members_ids: list):
                 json=data,
             )
             if response.status_code == 200:
-                logging.info(f"Updated group with union members {union_members_ids} from dwh database")
+                logging.info(f"Updated group with union member {union_member} from dwh database")
             else:
                 logging.error(
-                    f"Update group with union members {union_members_ids} copy to backend failed with code: {response.status_code}\n Response text: {response.text}"
+                    f"Update group with union member {union_member} copy to backend failed with code: {response.status_code}\n Response text: {response.text}"
                 )
     except Exception as e:
         logging.error(f"Error sending data to backend: {str(e)}")
@@ -335,6 +335,7 @@ def remove_non_union_members_from_union_group(union_members_ids: list):
 with DAG(
     dag_id="union_member_to_backend",
     schedule=[Dataset("ODS_USERDATA")],
+    inlets = [Dataset("ODS_USERDATA")],
     start_date=datetime.datetime(start_year, start_month, start_day),
     catchup=False,
     tags=["ods", "userdata", "union_member", "backend"],

--- a/dags/ods/user/user_to_back.py
+++ b/dags/ods/user/user_to_back.py
@@ -334,7 +334,7 @@ def remove_non_union_members_from_union_group(union_members_ids: list):
 
 with DAG(
     dag_id="union_member_to_backend",
-    schedule=[Dataset("ODS_USERDATA.student_id")],
+    schedule=[Dataset("ODS_USERDATA")],
     start_date=datetime.datetime(start_year, start_month, start_day),
     catchup=False,
     tags=["ods", "userdata", "union_member", "backend"],

--- a/dags/ods/user/user_to_back.py
+++ b/dags/ods/user/user_to_back.py
@@ -335,7 +335,7 @@ def remove_non_union_members_from_union_group(union_members_ids: list):
 with DAG(
     dag_id="union_member_to_backend",
     schedule=[Dataset("ODS_USERDATA")],
-    inlets = [Dataset("ODS_USERDATA")],
+    inlets=[Dataset("ODS_USERDATA")],
     start_date=datetime.datetime(start_year, start_month, start_day),
     catchup=False,
     tags=["ods", "userdata", "union_member", "backend"],


### PR DESCRIPTION
Проблема:
DAG `union_member_to_backend` не запускался по Dataset-триггеру, так как producer (DAG `ODS_USER_INFO.info`) и consumer использовали разные имена Dataset:
- producer публиковал `ODS_USERDATA`
- consumer ожидал `ODS_USERDATA.student_id`

Из-за этого Airflow не создавал событие для ожидаемого Dataset, и DAG не триггерился.

Решение:
- привёл Dataset к одному имени
- producer теперь публикует `ODS_USERDATA`
- consumer ожидает `ODS_USERDATA`