### PR TITLE
fix inlets

### DIFF
--- a/dags/ods/user/user_to_back.py
+++ b/dags/ods/user/user_to_back.py
@@ -335,14 +335,13 @@ def remove_non_union_members_from_union_group(union_members_ids: list):
 with DAG(
     dag_id="union_member_to_backend",
     schedule=[Dataset("ODS_USERDATA")],
-    inlets=[Dataset("ODS_USERDATA")],
     start_date=datetime.datetime(start_year, start_month, start_day),
     catchup=False,
     tags=["ods", "userdata", "union_member", "backend"],
     default_args={"owner": "VladislavVoskoboinik", "retries": 3, "retry_delay": datetime.timedelta(minutes=5)},
 ):
 
-    @task
+    @task(inlets=[Dataset("ODS_USERDATA")])
     def get_union_members_ids():
         return get_union_members_ids_from_dwh()
 


### PR DESCRIPTION
Импорт ДАГа в airflow ломался из-за неправильного расположения  `inlets`

- `inlets` перемещен в блок task 
